### PR TITLE
merge to master

### DIFF
--- a/changelog.yaml
+++ b/changelog.yaml
@@ -51,7 +51,12 @@
 - version: NEXT
   date: TBD
   changes:
-
+     - type: bug
+       impact: patch
+       title: Fix deletion bug #241
+       description: |-
+         When a pipeline run was deleted the state and the result were not updated in some edge cases. This is fixed now.
+       pullRequestNumber: 250
 - version: "0.12.1"
   date: 2021-07-28
   changes:

--- a/pkg/runctl/controller_test.go
+++ b/pkg/runctl/controller_test.go
@@ -187,86 +187,152 @@ func getAPIPipelineRun(cf *fake.ClientFactory, name, namespace string) (*api.Pip
 }
 
 func Test_Controller_syncHandler_delete(t *testing.T) {
-	for _, test := range []struct {
-		name                  string
-		runManagerExpectation func(*runmocks.MockManager)
-		hasFinalizer          bool
-		expectedError         bool
-		expectedFinalizer     bool
-		expectedResult        api.Result
-		expectedState         api.State
-	}{
-
-		{name: "delete with finalizer ok",
-			runManagerExpectation: func(rm *runmocks.MockManager) {
-				rm.EXPECT().Cleanup(gomock.Any()).Return(nil)
-			},
-			hasFinalizer:      true,
-			expectedError:     false,
-			expectedFinalizer: false,
-			expectedResult:    api.ResultDeleted,
-			expectedState:     api.StateFinished,
-		},
-		{name: "delete with finalizer fail",
-			runManagerExpectation: func(rm *runmocks.MockManager) {
-				rm.EXPECT().Cleanup(gomock.Any()).Return(fmt.Errorf("expected"))
-			},
-			hasFinalizer:      true,
-			expectedError:     true,
-			expectedFinalizer: true,
-			expectedResult:    api.ResultUndefined,
-			expectedState:     api.StateNew,
-		},
-		{name: "delete without finalizer already done",
-			runManagerExpectation: func(rm *runmocks.MockManager) {},
-			hasFinalizer:          false,
-			expectedError:         false,
-			expectedFinalizer:     false,
-			expectedResult:        api.ResultUndefined,
-		},
+	for _, currentState := range []api.State{
+		api.StateNew,
+		api.StateWaiting,
+		api.StatePreparing,
+		api.StateRunning,
+		api.StateCleaning,
+		api.StateUndefined,
 	} {
-		t.Run(test.name, func(t *testing.T) {
-			test := test
-			t.Parallel()
 
-			// SETUP
-			run := fake.PipelineRun("foo", "ns1", api.PipelineSpec{})
-			if test.hasFinalizer {
-				run.ObjectMeta.Finalizers = []string{k8s.FinalizerName}
-			}
-			now := metav1.Now()
-			run.SetDeletionTimestamp(&now)
-			controller, cf := newController(run)
-			mockCtrl := gomock.NewController(t)
-			defer mockCtrl.Finish()
-			runManager := runmocks.NewMockManager(mockCtrl)
-			test.runManagerExpectation(runManager)
-			controller.testing = &controllerTesting{
-				runManagerStub:             runManager,
-				loadPipelineRunsConfigStub: newEmptyRunsConfig,
-			}
+		expectedStateOnError := currentState
+		if currentState == api.StateUndefined {
+			expectedStateOnError = api.StateNew
+		}
 
-			// EXERCISE
-			err := controller.syncHandler("ns1/foo")
+		for _, test := range []struct {
+			name                  string
+			runManagerExpectation func(*runmocks.MockManager)
+			hasFinalizer          bool
+			expectedError         bool
+			expectedFinalizer     bool
+			expectedResult        api.Result
+			expectedState         api.State
+		}{
 
-			// VERIFY
-			if test.expectedError {
-				assert.Assert(t, err != nil)
-			} else {
+			{name: "delete with finalizer ok",
+				runManagerExpectation: func(rm *runmocks.MockManager) {
+					rm.EXPECT().Cleanup(gomock.Any()).Return(nil)
+				},
+				hasFinalizer:      true,
+				expectedError:     false,
+				expectedFinalizer: false,
+				expectedResult:    api.ResultDeleted,
+				expectedState:     api.StateFinished,
+			},
+			{name: "delete with finalizer fail",
+				runManagerExpectation: func(rm *runmocks.MockManager) {
+					rm.EXPECT().Cleanup(gomock.Any()).Return(fmt.Errorf("expected"))
+				},
+				hasFinalizer:      true,
+				expectedError:     true,
+				expectedFinalizer: true,
+				expectedResult:    api.ResultUndefined,
+				expectedState:     expectedStateOnError,
+			},
+			{name: "delete without finalizer ensure finished state",
+				runManagerExpectation: func(rm *runmocks.MockManager) {
+					rm.EXPECT().Cleanup(gomock.Any()).Return(nil)
+				},
+				hasFinalizer:      false,
+				expectedError:     false,
+				expectedFinalizer: false,
+				expectedResult:    api.ResultDeleted,
+				expectedState:     api.StateFinished,
+			},
+		} {
+			t.Run(fmt.Sprintf("%s current state %s", test.name, currentState), func(t *testing.T) {
+				currentState := currentState
+				test := test
+				t.Parallel()
+
+				// SETUP
+				run := fake.PipelineRun("foo", "ns1", api.PipelineSpec{})
+				if test.hasFinalizer {
+					run.ObjectMeta.Finalizers = []string{k8s.FinalizerName}
+				}
+				run.Status.State = currentState
+				now := metav1.Now()
+				run.SetDeletionTimestamp(&now)
+				controller, cf := newController(run)
+				mockCtrl := gomock.NewController(t)
+				defer mockCtrl.Finish()
+				runManager := runmocks.NewMockManager(mockCtrl)
+				test.runManagerExpectation(runManager)
+				controller.testing = &controllerTesting{
+					runManagerStub:             runManager,
+					loadPipelineRunsConfigStub: newEmptyRunsConfig,
+				}
+				// EXERCISE
+				err := controller.syncHandler("ns1/foo")
+
+				// VERIFY
+				if test.expectedError {
+					assert.Assert(t, err != nil)
+				} else {
+					assert.NilError(t, err)
+				}
+				result, err := getAPIPipelineRun(cf, "foo", "ns1")
 				assert.NilError(t, err)
-			}
-			result, err := getAPIPipelineRun(cf, "foo", "ns1")
-			assert.NilError(t, err)
-			klog.Infof("%+v", result.Status)
+				klog.Infof("%+v", result.Status)
 
-			assert.Equal(t, test.expectedResult, result.Status.Result)
-			assert.Equal(t, test.expectedState, result.Status.State)
-			if test.expectedFinalizer {
-				assert.Assert(t, len(result.GetFinalizers()) == 1)
-			} else {
+				assert.Equal(t, test.expectedResult, result.Status.Result)
+				assert.Equal(t, test.expectedState, result.Status.State)
+				if test.expectedFinalizer {
+					assert.Assert(t, len(result.GetFinalizers()) == 1)
+				} else {
+					assert.Assert(t, len(result.GetFinalizers()) == 0)
+				}
+			})
+		}
+	}
+}
+
+func Test_Controller_syncHandler_delete_on_finished_keeps_result_unchanged(t *testing.T) {
+	for _, currentResult := range []api.Result{
+		api.ResultDeleted,
+		api.ResultSuccess,
+		api.ResultErrorContent,
+		api.ResultAborted,
+		api.ResultErrorConfig,
+		api.ResultErrorInfra} {
+		for _, hasFinalizer := range []bool{true, false} {
+			t.Run(fmt.Sprintf("finalizer %t current result %s", hasFinalizer, currentResult), func(t *testing.T) {
+				currentResult := currentResult
+				hasFinalizer := hasFinalizer
+				t.Parallel()
+				// SETUP
+				run := fake.PipelineRun("foo", "ns1", api.PipelineSpec{})
+				if hasFinalizer {
+					run.ObjectMeta.Finalizers = []string{k8s.FinalizerName}
+				}
+				run.Status.State = api.StateFinished
+				run.Status.Result = currentResult
+				now := metav1.Now()
+				run.SetDeletionTimestamp(&now)
+				controller, cf := newController(run)
+				mockCtrl := gomock.NewController(t)
+				defer mockCtrl.Finish()
+				runManager := runmocks.NewMockManager(mockCtrl)
+				controller.testing = &controllerTesting{
+					runManagerStub:             runManager,
+					loadPipelineRunsConfigStub: newEmptyRunsConfig,
+				}
+				// EXERCISE
+				err := controller.syncHandler("ns1/foo")
+
+				// VERIFY
+				assert.NilError(t, err)
+				result, err := getAPIPipelineRun(cf, "foo", "ns1")
+				assert.NilError(t, err)
+				klog.Infof("%+v", result.Status)
+
+				assert.Equal(t, currentResult, result.Status.Result)
+				assert.Equal(t, api.StateFinished, result.Status.State)
 				assert.Assert(t, len(result.GetFinalizers()) == 0)
-			}
-		})
+			})
+		}
 	}
 }
 
@@ -337,6 +403,7 @@ func Test_Controller_syncHandler_mock_start(t *testing.T) {
 				name:         "new_get_cofig_fail_not_recoverable",
 				pipelineSpec: api.PipelineSpec{},
 				runManagerExpectation: func(rm *runmocks.MockManager, run *runmocks.MockRun) {
+					rm.EXPECT().Cleanup(gomock.Any()).Return(nil)
 				},
 				pipelineRunsConfigStub: func() (*cfg.PipelineRunsConfigStruct, error) {
 					return nil, error1

--- a/test/integrationtest/pipelineRun_testbuilders.go
+++ b/test/integrationtest/pipelineRun_testbuilders.go
@@ -214,11 +214,8 @@ func PipelineRunWrongJenkinsfileRepo(Namespace string, runID *api.CustomJSON) f.
 				builder.JenkinsFileSpec("https://github.com/SAP/steward-foo",
 					"Jenkinsfile"),
 			)),
-		Check: f.PipelineRunMessageOnFinished(`Command ['git' 'clone' 'https://github.com/SAP/steward-foo' '.'] failed with exit code 128
-Error output:
-Cloning into '.'...
-fatal: could not read Username for 'https://github.com': No such device or address`),
-		Timeout: 120 * time.Second,
+		Check:   f.PipelineRunHasStateResult(api.ResultErrorContent),
+		Timeout: 300 * time.Second,
 	}
 }
 
@@ -234,11 +231,8 @@ func PipelineRunWrongJenkinsfileRepoWithUser(Namespace string, runID *api.Custom
 				),
 			)),
 		Secrets: []*v1.Secret{builder.SecretBasicAuth("repo-auth", Namespace, "bar", "baz")},
-		Check: f.PipelineRunMessageOnFinished(`Command ['git' 'clone' 'https://github.com/SAP/steward-foo' '.'] failed with exit code 128
-Error output:
-Cloning into '.'...
-fatal: could not read Username for 'https://github.com': No such device or address`),
-		Timeout: 120 * time.Second,
+		Check:   f.PipelineRunHasStateResult(api.ResultErrorContent),
+		Timeout: 300 * time.Second,
 	}
 }
 


### PR DESCRIPTION
### Description

<!--
  The description should provide all necessary information for a reviewer.
  - What does this PR change, what's the reason for the change, how can it be tested
-->
&lt;Add detailed description for reviewers here.&gt;


### Submitter checklist

- [ ] Change has been tested (on a back-end cluster)
- [ ] (If applicable) Jira backlog item ID added to the PR title and the [changelog.yaml] entry
- [ ] [changelog.yaml] entry with upgrade notes is prepared and appropriate for the audience affected by the change (users or developer, depending on the change)
- [ ] Semantic version diffed against [last release][releases] and updated accordingly. In this project the version has to be maintained here:
    - [/charts/steward/Chart.yaml](https://github.com/SAP/stewardci-core/blob/master/charts/steward/Chart.yaml) (`version` and `appVersion`)

In case dependencies have been updated:
- [ ] Links to external changelogs, since the last release of our component, added to the [changelog.yaml] entry (description).
- [ ] Changelogs read thoroughly, potential impact described, upgrade notes prepared (if necessary)
- [ ] Check if dependency updates affect our semantic version increment.

### Reviewer checklist

Before the changes are marked as `ready-for-merge`: 

- [ ] There is at least 1 approval for the pull request and no outstanding requests for change
- [ ] All voter checks have passed
- [ ] Conversations in the pull request are over OR it is explicit that a reviewer does not block the change
- [ ] The Pull Request title is understandable and reflects the changes well
- [ ] The Pull Request description is understandable and well documented
- [ ] [changelog.yaml] entry for this Pull Request has been added
    - [ ] Changelog entry contains all required information
    - [ ] 'Upgrade notes' are documented in changelog.yaml (if required)

[changelog.yaml]: https://github.com/SAP/stewardci-core/changelog.yaml
[releases]: https://github.com/SAP/stewardci-core/releases
