### PR TITLE
Completion time

### DIFF
--- a/pkg/k8s/mocks/mocks.go
+++ b/pkg/k8s/mocks/mocks.go
@@ -516,15 +516,15 @@ func (mr *MockPipelineRunMockRecorder) UpdateMessage(arg0 interface{}) *gomock.C
 }
 
 // UpdateResult mocks base method
-func (m *MockPipelineRun) UpdateResult(arg0 v1alpha1.Result) {
+func (m *MockPipelineRun) UpdateResult(arg0 v1alpha1.Result, arg1 v10.Time) {
 	m.ctrl.T.Helper()
-	m.ctrl.Call(m, "UpdateResult", arg0)
+	m.ctrl.Call(m, "UpdateResult", arg0, arg1)
 }
 
 // UpdateResult indicates an expected call of UpdateResult
-func (mr *MockPipelineRunMockRecorder) UpdateResult(arg0 interface{}) *gomock.Call {
+func (mr *MockPipelineRunMockRecorder) UpdateResult(arg0, arg1 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "UpdateResult", reflect.TypeOf((*MockPipelineRun)(nil).UpdateResult), arg0)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "UpdateResult", reflect.TypeOf((*MockPipelineRun)(nil).UpdateResult), arg0, arg1)
 }
 
 // UpdateRunNamespace mocks base method

--- a/pkg/k8s/pipelineRun.go
+++ b/pkg/k8s/pipelineRun.go
@@ -35,7 +35,7 @@ type PipelineRun interface {
 	DeleteFinalizerIfExists() error
 	InitState() error
 	UpdateState(api.State, metav1.Time) error
-	UpdateResult(api.Result)
+	UpdateResult(api.Result, metav1.Time)
 	UpdateContainer(*corev1.ContainerState)
 	StoreErrorAsMessage(error, string) error
 	UpdateRunNamespace(string)
@@ -211,14 +211,13 @@ func (r *pipelineRun) String() string {
 }
 
 // UpdateResult of the pipeline run
-func (r *pipelineRun) UpdateResult(result api.Result) {
+func (r *pipelineRun) UpdateResult(result api.Result, ts metav1.Time) {
 	r.ensureCopy()
 	// the call below returns the error from the function. This error is always nil. Hence there
 	// is no need to return that always-nil-error.
 	r.mustChangeStatusAndStoreForRetry(func(s *api.PipelineStatus) (commitRecorderFunc, error) {
 		s.Result = result
-		now := metav1.Now()
-		s.FinishedAt = &now
+		s.FinishedAt = &ts
 		return nil, nil
 	})
 }

--- a/pkg/k8s/pipelineRun_test.go
+++ b/pkg/k8s/pipelineRun_test.go
@@ -96,7 +96,7 @@ func Test_NewPipelineRun_IsCopy(t *testing.T) {
 
 	// VERIFY
 	assert.NilError(t, err)
-	examinee.UpdateResult(api.ResultSuccess)
+	examinee.UpdateResult(api.ResultSuccess, metav1.Now())
 	assert.Equal(t, api.ResultUndefined, run.Status.Result)
 	assert.Equal(t, api.ResultSuccess, examinee.GetStatus().Result)
 }
@@ -411,7 +411,7 @@ func Test_pipelineRun_UpdateResult(t *testing.T) {
 	assert.Assert(t, examinee.GetStatus().FinishedAt.IsZero())
 
 	// EXERCISE
-	examinee.UpdateResult(api.ResultSuccess)
+	examinee.UpdateResult(api.ResultSuccess, metav1.Now())
 
 	// VERIFY
 	status := examinee.GetStatus()

--- a/pkg/runctl/controller.go
+++ b/pkg/runctl/controller.go
@@ -438,9 +438,10 @@ func (c *Controller) syncHandler(key string) error {
 		pipelineRun.UpdateContainer(containerInfo)
 		if finished, result := run.IsFinished(); finished {
 			msg := run.GetMessage()
+			completionTime := *run.GetCompletionTime()
 			pipelineRun.UpdateMessage(msg)
-			pipelineRun.UpdateResult(result, metav1.Now())
-			if err = c.changeState(pipelineRun, api.StateCleaning, *run.GetCompletionTime()); err != nil {
+			pipelineRun.UpdateResult(result, completionTime)
+			if err = c.changeState(pipelineRun, api.StateCleaning, completionTime); err != nil {
 				return err
 			}
 			if err = c.commitStatusAndMeter(pipelineRun); err != nil {

--- a/pkg/runctl/controller.go
+++ b/pkg/runctl/controller.go
@@ -371,7 +371,7 @@ func (c *Controller) syncHandler(key string) error {
 			if resultClass != api.ResultUndefined {
 				pipelineRun.UpdateMessage(err.Error())
 				pipelineRun.StoreErrorAsMessage(err, "preparing failed")
-				return c.prepareCleaningAndCountResult(pipelineRun, resultClass, metav1.Now())
+				return c.setCleaningAndCountResult(pipelineRun, resultClass, metav1.Now())
 			}
 			return err
 		}
@@ -390,7 +390,7 @@ func (c *Controller) syncHandler(key string) error {
 				return err
 			}
 			pipelineRun.StoreErrorAsMessage(err, "waiting failed")
-			return c.prepareCleaningAndCountResult(pipelineRun, api.ResultErrorInfra, metav1.Now())
+			return c.setCleaningAndCountResult(pipelineRun, api.ResultErrorInfra, metav1.Now())
 		}
 		started := run.GetStartTime()
 		if started != nil {
@@ -414,7 +414,7 @@ func (c *Controller) syncHandler(key string) error {
 		pipelineRun.UpdateContainer(containerInfo)
 		if finished, result := run.IsFinished(); finished {
 			pipelineRun.UpdateMessage(run.GetMessage())
-			return c.prepareCleaningAndCountResult(pipelineRun, result, *run.GetCompletionTime())
+			return c.setCleaningAndCountResult(pipelineRun, result, *run.GetCompletionTime())
 		} else {
 			// commit container update
 			c.commitStatusAndMeter(pipelineRun)
@@ -437,7 +437,7 @@ func (c *Controller) changeAndCommitStateAndMeter(pipelineRun k8s.PipelineRun, s
 	}
 	return c.commitStatusAndMeter(pipelineRun)
 }
-func (c *Controller) prepareCleaningAndCountResult(pipelineRun k8s.PipelineRun, result api.Result, ts metav1.Time) error {
+func (c *Controller) setCleaningAndCountResult(pipelineRun k8s.PipelineRun, result api.Result, ts metav1.Time) error {
 	// TODO: revisit: during state cleaning we have already the result. From the pure doctrine point of view
 	// that is questionable since only final states (finished) have a result. But ok, cleaning is close to finished ...
 	pipelineRun.UpdateResult(result, ts)

--- a/pkg/runctl/controller.go
+++ b/pkg/runctl/controller.go
@@ -424,8 +424,7 @@ func (c *Controller) syncHandler(key string) error {
 		containerInfo := run.GetContainerInfo()
 		pipelineRun.UpdateContainer(containerInfo)
 		if finished, result := run.IsFinished(); finished {
-			msg := run.GetMessage()
-			pipelineRun.UpdateMessage(msg)
+			pipelineRun.UpdateMessage(run.GetMessage())
 			return c.commonHandlingTODOFindBetterName(pipelineRun, result, *run.GetCompletionTime())
 		} else {
 			// commit container update

--- a/pkg/runctl/controller.go
+++ b/pkg/runctl/controller.go
@@ -427,14 +427,7 @@ func (c *Controller) syncHandler(key string) error {
 			msg := run.GetMessage()
 			completionTime := *run.GetCompletionTime()
 			pipelineRun.UpdateMessage(msg)
-			pipelineRun.UpdateResult(result, completionTime)
-			if err = c.changeState(pipelineRun, api.StateCleaning, completionTime); err != nil {
-				return err
-			}
-			if err = c.commitStatusAndMeter(pipelineRun); err != nil {
-				return err
-			}
-			c.metrics.CountResult(result)
+			return c.commonHandlingTODOFindBetterName(pipelineRun, result, completionTime)
 		} else {
 			// commit container update
 			c.commitStatusAndMeter(pipelineRun)

--- a/pkg/runctl/controller.go
+++ b/pkg/runctl/controller.go
@@ -374,7 +374,7 @@ func (c *Controller) syncHandler(key string) error {
 			if resultClass != api.ResultUndefined {
 				pipelineRun.UpdateMessage(err.Error())
 				pipelineRun.StoreErrorAsMessage(err, "preparing failed")
-				return c.commonErrorHandlingTODOFindBetterName(pipelineRun, resultClass)
+				return c.commonHandlingTODOFindBetterName(pipelineRun, resultClass, metav1.Now())
 			}
 			return err
 		}
@@ -396,7 +396,7 @@ func (c *Controller) syncHandler(key string) error {
 				return err
 			}
 			pipelineRun.StoreErrorAsMessage(err, "waiting failed")
-			return c.commonErrorHandlingTODOFindBetterName(pipelineRun, api.ResultErrorInfra)
+			return c.commonHandlingTODOFindBetterName(pipelineRun, api.ResultErrorInfra, metav1.Now())
 		}
 		started := run.GetStartTime()
 		if started != nil {
@@ -451,10 +451,9 @@ func (c *Controller) syncHandler(key string) error {
 	return nil
 }
 
-func (c *Controller) commonErrorHandlingTODOFindBetterName(pipelineRun k8s.PipelineRun, result api.Result) error {
-	now := metav1.Now()
-	pipelineRun.UpdateResult(result, now)
-	if errClean := c.changeState(pipelineRun, api.StateCleaning, now); errClean != nil {
+func (c *Controller) commonHandlingTODOFindBetterName(pipelineRun k8s.PipelineRun, result api.Result, ts metav1.Time) error {
+	pipelineRun.UpdateResult(result, ts)
+	if errClean := c.changeState(pipelineRun, api.StateCleaning, ts); errClean != nil {
 		return errClean
 	}
 	if err := c.commitStatusAndMeter(pipelineRun); err != nil {

--- a/pkg/runctl/controller.go
+++ b/pkg/runctl/controller.go
@@ -406,8 +406,9 @@ func (c *Controller) syncHandler(key string) error {
 				return err
 			}
 			pipelineRun.StoreErrorAsMessage(err, "running failed")
-			// TODO: why don't we set a result here? Maybe prepareCleaningAndCountResult ...
-			return c.changeAndCommitStateAndMeter(pipelineRun, api.StateCleaning, metav1.Now())
+			now := metav1.Now()
+			pipelineRun.UpdateResult(api.ResultErrorInfra, now)
+			return c.changeAndCommitStateAndMeter(pipelineRun, api.StateCleaning, now)
 		}
 		containerInfo := run.GetContainerInfo()
 		pipelineRun.UpdateContainer(containerInfo)

--- a/pkg/runctl/controller.go
+++ b/pkg/runctl/controller.go
@@ -400,7 +400,7 @@ func (c *Controller) syncHandler(key string) error {
 		}
 		started := run.GetStartTime()
 		if started != nil {
-			if err = c.changeState(pipelineRun, api.StateRunning, metav1.Now()); err != nil {
+			if err = c.changeState(pipelineRun, api.StateRunning, *started); err != nil {
 				return err
 			}
 			if err = c.commitStatusAndMeter(pipelineRun); err != nil {

--- a/pkg/runctl/controller.go
+++ b/pkg/runctl/controller.go
@@ -480,8 +480,7 @@ func (c *Controller) handleAborted(pipelineRun k8s.PipelineRun) error {
 	if intent == api.IntentAbort && pipelineRun.GetStatus().Result == api.ResultUndefined {
 		pipelineRun.UpdateMessage("Aborted")
 		now := metav1.Now()
-		pipelineRun.UpdateResult(api.ResultAborted, now)
-		return c.changeState(pipelineRun, api.StateCleaning, now)
+		return c.setCleaningAndCountResult(pipelineRun, api.ResultAborted, now)
 	}
 	return nil
 }

--- a/pkg/runctl/controller.go
+++ b/pkg/runctl/controller.go
@@ -425,9 +425,8 @@ func (c *Controller) syncHandler(key string) error {
 		pipelineRun.UpdateContainer(containerInfo)
 		if finished, result := run.IsFinished(); finished {
 			msg := run.GetMessage()
-			completionTime := *run.GetCompletionTime()
 			pipelineRun.UpdateMessage(msg)
-			return c.commonHandlingTODOFindBetterName(pipelineRun, result, completionTime)
+			return c.commonHandlingTODOFindBetterName(pipelineRun, result, *run.GetCompletionTime())
 		} else {
 			// commit container update
 			c.commitStatusAndMeter(pipelineRun)

--- a/pkg/runctl/controller.go
+++ b/pkg/runctl/controller.go
@@ -407,8 +407,7 @@ func (c *Controller) syncHandler(key string) error {
 			}
 			pipelineRun.StoreErrorAsMessage(err, "running failed")
 			now := metav1.Now()
-			pipelineRun.UpdateResult(api.ResultErrorInfra, now)
-			return c.changeAndCommitStateAndMeter(pipelineRun, api.StateCleaning, now)
+			return c.setCleaningAndCountResult(pipelineRun, api.ResultErrorInfra, now)
 		}
 		containerInfo := run.GetContainerInfo()
 		pipelineRun.UpdateContainer(containerInfo)

--- a/pkg/runctl/controller.go
+++ b/pkg/runctl/controller.go
@@ -415,7 +415,7 @@ func (c *Controller) syncHandler(key string) error {
 				return err
 			}
 			pipelineRun.StoreErrorAsMessage(err, "running failed")
-			// TODO: why don't we set a result here?
+			// TODO: why don't we set a result here? Maybe prepareCleaningAndCountResult ...
 			if errClean := c.changeState(pipelineRun, api.StateCleaning, metav1.Now()); errClean != nil {
 				return errClean
 			}

--- a/pkg/runctl/controller.go
+++ b/pkg/runctl/controller.go
@@ -405,15 +405,15 @@ func (c *Controller) syncHandler(key string) error {
 				return err
 			}
 			now := metav1.Now()
+			pipelineRun.UpdateResult(api.ResultErrorInfra, now)
 			if errClean := c.changeState(pipelineRun, api.StateCleaning, now); errClean != nil {
 				return errClean
 			}
 			pipelineRun.StoreErrorAsMessage(err, "waiting failed")
-			pipelineRun.UpdateResult(api.ResultErrorInfra, now)
 			if err := c.commitStatusAndMeter(pipelineRun); err != nil {
 				return err
 			}
-			c.metrics.CountResult(api.ResultErrorInfra)
+			c.metrics.CountResult(pipelineRun.GetStatus().Result)
 			return nil
 		}
 		started := run.GetStartTime()

--- a/pkg/runctl/controller.go
+++ b/pkg/runctl/controller.go
@@ -407,10 +407,7 @@ func (c *Controller) syncHandler(key string) error {
 			}
 			pipelineRun.StoreErrorAsMessage(err, "running failed")
 			// TODO: why don't we set a result here? Maybe prepareCleaningAndCountResult ...
-			if errClean := c.changeState(pipelineRun, api.StateCleaning, metav1.Now()); errClean != nil {
-				return errClean
-			}
-			return c.commitStatusAndMeter(pipelineRun)
+			return c.changeAndCommitStateAndMeter(pipelineRun, api.StateCleaning, metav1.Now())
 		}
 		containerInfo := run.GetContainerInfo()
 		pipelineRun.UpdateContainer(containerInfo)

--- a/pkg/runctl/controller.go
+++ b/pkg/runctl/controller.go
@@ -440,7 +440,7 @@ func (c *Controller) syncHandler(key string) error {
 			msg := run.GetMessage()
 			pipelineRun.UpdateMessage(msg)
 			pipelineRun.UpdateResult(result)
-			if err = c.changeState(pipelineRun, api.StateCleaning, metav1.Now()); err != nil {
+			if err = c.changeState(pipelineRun, api.StateCleaning, *run.GetCompletionTime()); err != nil {
 				return err
 			}
 			if err = c.commitStatusAndMeter(pipelineRun); err != nil {

--- a/pkg/runctl/controller.go
+++ b/pkg/runctl/controller.go
@@ -441,11 +441,8 @@ func (c *Controller) prepareCleaningAndCountResult(pipelineRun k8s.PipelineRun, 
 	// TODO: revisit: during state cleaning we have already the result. From the pure doctrine point of view
 	// that is questionable since only final states (finished) have a result. But ok, cleaning is close to finished ...
 	pipelineRun.UpdateResult(result, ts)
-	if errClean := c.changeState(pipelineRun, api.StateCleaning, ts); errClean != nil {
+	if errClean := c.changeAndCommitStateAndMeter(pipelineRun, api.StateCleaning, ts); errClean != nil {
 		return errClean
-	}
-	if err := c.commitStatusAndMeter(pipelineRun); err != nil {
-		return err
 	}
 	c.metrics.CountResult(pipelineRun.GetStatus().Result)
 	return nil

--- a/pkg/runctl/controller_test.go
+++ b/pkg/runctl/controller_test.go
@@ -627,7 +627,7 @@ func Test_Controller_syncHandler_mock(t *testing.T) {
 					rm.EXPECT().GetRun(gomock.Any()).Return(nil, error1)
 				},
 				pipelineRunsConfigStub: newEmptyRunsConfig,
-				expectedResult:         "",
+				expectedResult:         "error_infra",
 				expectedState:          api.StateCleaning,
 				expectedMessage:        "running failed .*error1",
 			},

--- a/pkg/runctl/controller_test.go
+++ b/pkg/runctl/controller_test.go
@@ -642,6 +642,8 @@ func Test_Controller_syncHandler_mock(t *testing.T) {
 						&corev1.ContainerState{
 							Running: &corev1.ContainerStateRunning{},
 						})
+					now := metav1.Now()
+					run.EXPECT().GetCompletionTime().Return(&now)
 					run.EXPECT().IsFinished().Return(true, api.ResultTimeout)
 					run.EXPECT().GetMessage()
 					rm.EXPECT().GetRun(gomock.Any()).Return(run, nil)
@@ -663,7 +665,9 @@ func Test_Controller_syncHandler_mock(t *testing.T) {
 								Message: "message",
 							},
 						})
+					now := metav1.Now()
 					run.EXPECT().IsFinished().Return(true, api.ResultSuccess)
+					run.EXPECT().GetCompletionTime().Return(&now)
 					run.EXPECT().GetMessage()
 					rm.EXPECT().GetRun(gomock.Any()).Return(run, nil)
 				},

--- a/pkg/runctl/run.go
+++ b/pkg/runctl/run.go
@@ -24,6 +24,11 @@ func (r *tektonRun) GetStartTime() *metav1.Time {
 	return r.tektonTaskRun.Status.StartTime
 }
 
+// GetCompletionTime returns completion time of run if already completed
+func (r *tektonRun) GetCompletionTime() *metav1.Time {
+	return r.tektonTaskRun.Status.CompletionTime
+}
+
 // GetContainerInfo returns the state of the Jenkinsfile Runner container
 // as reported in the Tekton TaskRun status.
 func (r *tektonRun) GetContainerInfo() *corev1.ContainerState {

--- a/pkg/runctl/run/interfaces.go
+++ b/pkg/runctl/run/interfaces.go
@@ -19,6 +19,7 @@ type Manager interface {
 type Run interface {
 	GetStartTime() *metav1.Time
 	IsFinished() (bool, steward.Result)
+	GetCompletionTime() *metav1.Time
 	GetContainerInfo() *corev1.ContainerState
 	GetMessage() string
 }

--- a/pkg/runctl/run/mocks/mocks.go
+++ b/pkg/runctl/run/mocks/mocks.go
@@ -61,6 +61,20 @@ func (m *MockRun) EXPECT() *MockRunMockRecorder {
 	return m.recorder
 }
 
+// GetCompletionTime mocks base method
+func (m *MockRun) GetCompletionTime() *v10.Time {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "GetCompletionTime")
+	ret0, _ := ret[0].(*v10.Time)
+	return ret0
+}
+
+// GetCompletionTime indicates an expected call of GetCompletionTime
+func (mr *MockRunMockRecorder) GetCompletionTime() *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetCompletionTime", reflect.TypeOf((*MockRun)(nil).GetCompletionTime))
+}
+
 // GetContainerInfo mocks base method
 func (m *MockRun) GetContainerInfo() *v1.ContainerState {
 	m.ctrl.T.Helper()


### PR DESCRIPTION
### Description

<!--
  The description should provide all necessary information for a reviewer.
  - What does this PR change, what's the reason for the change, how can it be tested
-->
&lt;Add detailed description for reviewers here.&gt;


### Submitter checklist

- [ ] Change has been tested (on a back-end cluster)
- [ ] (If applicable) Jira backlog item ID added to the PR title and the [changelog.yaml] entry
- [ ] [changelog.yaml] entry with upgrade notes is prepared and appropriate for the audience affected by the change (users or developer, depending on the change)
- [ ] Semantic version diffed against [last release][releases] and updated accordingly. In this project the version has to be maintained here:
    - [/charts/steward/Chart.yaml](https://github.com/SAP/stewardci-core/blob/master/charts/steward/Chart.yaml) (`version` and `appVersion`)

In case dependencies have been updated:
- [ ] Links to external changelogs, since the last release of our component, added to the [changelog.yaml] entry (description).
- [ ] Changelogs read thoroughly, potential impact described, upgrade notes prepared (if necessary)
- [ ] Check if dependency updates affect our semantic version increment.

### Reviewer checklist

Before the changes are marked as `ready-for-merge`: 

- [ ] There is at least 1 approval for the pull request and no outstanding requests for change
- [ ] All voter checks have passed
- [ ] Conversations in the pull request are over OR it is explicit that a reviewer does not block the change
- [ ] The Pull Request title is understandable and reflects the changes well
- [ ] The Pull Request description is understandable and well documented
- [ ] [changelog.yaml] entry for this Pull Request has been added
    - [ ] Changelog entry contains all required information
    - [ ] 'Upgrade notes' are documented in changelog.yaml (if required)

[changelog.yaml]: https://github.com/SAP/stewardci-core/changelog.yaml
[releases]: https://github.com/SAP/stewardci-core/releases
